### PR TITLE
Now theaterOwner can create the Screen And Seats

### DIFF
--- a/src/main/java/com/tenjiku/mtb/controller/ScreenController.java
+++ b/src/main/java/com/tenjiku/mtb/controller/ScreenController.java
@@ -1,0 +1,37 @@
+package com.tenjiku.mtb.controller;
+
+import com.tenjiku.mtb.dto.entry_dto.screen.ScreenDTO;
+import com.tenjiku.mtb.dto.exit_dto.screen.ScreenResponseDTO;
+import com.tenjiku.mtb.service.ScreenService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@AllArgsConstructor
+@Validated
+public class ScreenController {
+
+   private final ScreenService screenService;
+
+    @PostMapping(value = "/addScreen")
+    public ResponseEntity<?> createScreen(@RequestParam String theaterId,@Valid @RequestBody ScreenDTO screenDTO){
+        ScreenResponseDTO screen =screenService.createScreen(theaterId,screenDTO);
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{Id}")
+                .buildAndExpand(screen.getScreenId())
+                .toUri();
+        return ResponseEntity.created(location).body(screen);
+    }
+
+    @GetMapping(value = "/theater/{theaterId}/screen/{screenId}")
+    public  ResponseEntity<?> findScreenById(@PathVariable String theaterId,@PathVariable String ScreenId){
+        return ResponseEntity.ok(screenService.findScreenById(theaterId,ScreenId));
+    }
+}

--- a/src/main/java/com/tenjiku/mtb/controller/TheaterController.java
+++ b/src/main/java/com/tenjiku/mtb/controller/TheaterController.java
@@ -4,8 +4,10 @@ import com.tenjiku.mtb.dto.entry_dto.theatercreation.TheaterDTO;
 import com.tenjiku.mtb.dto.exit_dto.theatercreation.TheaterResponceDTO;
 import com.tenjiku.mtb.dto.update_dto.theatercreation.TheaterUpdateDTO;
 import com.tenjiku.mtb.service.TheaterService;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -13,15 +15,16 @@ import java.net.URI;
 
 @RestController
 @AllArgsConstructor
+@Validated
 public class TheaterController {
 
     private final TheaterService theaterService;
 
     @PostMapping(value = "/theaters")
-    public ResponseEntity<?> userRegister(@RequestParam String id, @RequestBody TheaterDTO theaterDTO){
-        System.out.println("inbound dto :"+theaterDTO);
+    public ResponseEntity<?> userRegister( @RequestParam String id, @Valid @RequestBody TheaterDTO theaterDTO){
+
         TheaterResponceDTO createdTheater=theaterService.register(id,theaterDTO);
-        System.out.println("outbound Responce dto :"+createdTheater);
+
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{name}")
@@ -40,7 +43,7 @@ public class TheaterController {
     }
 
     @PutMapping(value = "/updates")
-    public ResponseEntity<?> updateTheater(@RequestParam String id, @RequestBody TheaterUpdateDTO theaterUpdateDTO){
+    public ResponseEntity<?> updateTheater(@RequestParam String id, @Valid @RequestBody TheaterUpdateDTO theaterUpdateDTO){
         return ResponseEntity.ok(theaterService.updateTheater(id,theaterUpdateDTO));
     }
 

--- a/src/main/java/com/tenjiku/mtb/dto/entry_dto/screen/ScreenDTO.java
+++ b/src/main/java/com/tenjiku/mtb/dto/entry_dto/screen/ScreenDTO.java
@@ -1,0 +1,25 @@
+package com.tenjiku.mtb.dto.entry_dto.screen;
+
+import com.tenjiku.mtb.entity.enums.ScreenType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ScreenDTO {
+
+    @NotNull(message = "Screen type is required")
+    private ScreenType screenType;
+
+    @NotNull(message = "Capacity is required")
+    @Min(value = 1, message = "Capacity must be at least 1")
+    private Integer capacity;
+
+    @NotNull(message = "Number of rows is required")
+    @Min(value = 1, message = "Number of rows must be at least 1")
+    private Integer noOfRows;
+
+
+}

--- a/src/main/java/com/tenjiku/mtb/dto/exit_dto/screen/ScreenResponseDTO.java
+++ b/src/main/java/com/tenjiku/mtb/dto/exit_dto/screen/ScreenResponseDTO.java
@@ -1,0 +1,23 @@
+package com.tenjiku.mtb.dto.exit_dto.screen;
+
+import com.tenjiku.mtb.entity.Theater;
+import com.tenjiku.mtb.entity.enums.ScreenType;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+@Setter
+@Getter
+@ToString
+public class ScreenResponseDTO {
+    private String screenId;
+    private ScreenType screenType;
+    private Integer capacity;
+    private Integer noOfRows;
+    private Theater theater;
+    private List<SeatResponseDTO> seats;
+    private LocalDateTime createdAt;
+    private String createdBy;
+}

--- a/src/main/java/com/tenjiku/mtb/dto/exit_dto/screen/SeatResponseDTO.java
+++ b/src/main/java/com/tenjiku/mtb/dto/exit_dto/screen/SeatResponseDTO.java
@@ -1,0 +1,19 @@
+package com.tenjiku.mtb.dto.exit_dto.screen;
+
+import com.tenjiku.mtb.entity.Screen;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SeatResponseDTO {
+
+    private String seatId;
+
+    private String name;
+
+    private Screen screen;
+
+}

--- a/src/main/java/com/tenjiku/mtb/dto/update_dto/screen/ScreenUpdateDTO.java
+++ b/src/main/java/com/tenjiku/mtb/dto/update_dto/screen/ScreenUpdateDTO.java
@@ -1,0 +1,21 @@
+package com.tenjiku.mtb.dto.update_dto.screen;
+
+import com.tenjiku.mtb.entity.Seats;
+import com.tenjiku.mtb.entity.Theater;
+import com.tenjiku.mtb.entity.enums.ScreenType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ScreenUpdateDTO {
+
+    private ScreenType screenType;
+
+    @Min(value = 1, message = "Capacity must be at least 1")
+    private Integer capacity;
+
+    @Min(value = 1, message = "Number of rows must be at least 1")
+    private Integer noOfRows;
+}

--- a/src/main/java/com/tenjiku/mtb/entity/Screen.java
+++ b/src/main/java/com/tenjiku/mtb/entity/Screen.java
@@ -1,0 +1,46 @@
+package com.tenjiku.mtb.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.tenjiku.mtb.entity.enums.ScreenType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.LastModifiedDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Screen {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String screenId;
+
+    private ScreenType screenType;
+
+    private Integer capacity;
+
+    private Integer noOfRows;
+
+
+    @ManyToOne
+    private Theater theater;
+
+    @OneToMany(mappedBy = "screen", cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+    @OrderBy(value = "name")
+    @JsonIgnore
+    private List<Seats> seats;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String createdBy;
+}

--- a/src/main/java/com/tenjiku/mtb/entity/Seats.java
+++ b/src/main/java/com/tenjiku/mtb/entity/Seats.java
@@ -1,0 +1,40 @@
+package com.tenjiku.mtb.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Seats {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "seat_id")
+    private String seatId;
+
+    @Column(name = "name")
+    private String name;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
+    @JoinColumn(name = "screen_id")
+    private Screen screen;
+
+    @Column(name = "is_delete")
+    private boolean isDelete;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private Instant createdAt;
+}

--- a/src/main/java/com/tenjiku/mtb/entity/enums/ScreenType.java
+++ b/src/main/java/com/tenjiku/mtb/entity/enums/ScreenType.java
@@ -1,0 +1,7 @@
+package com.tenjiku.mtb.entity.enums;
+
+public enum ScreenType {
+    IMAX,
+    TWO_D,
+    THREE_D
+}

--- a/src/main/java/com/tenjiku/mtb/exception/NoOfRowsExceedCapacityException.java
+++ b/src/main/java/com/tenjiku/mtb/exception/NoOfRowsExceedCapacityException.java
@@ -1,0 +1,7 @@
+package com.tenjiku.mtb.exception;
+
+public class NoOfRowsExceedCapacityException extends RuntimeException {
+    public NoOfRowsExceedCapacityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tenjiku/mtb/exception/ScreenNotFoundException.java
+++ b/src/main/java/com/tenjiku/mtb/exception/ScreenNotFoundException.java
@@ -1,0 +1,7 @@
+package com.tenjiku.mtb.exception;
+
+public class ScreenNotFoundException extends RuntimeException {
+    public ScreenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tenjiku/mtb/exception/UserNotFoundException.java
+++ b/src/main/java/com/tenjiku/mtb/exception/UserNotFoundException.java
@@ -1,7 +1,5 @@
 package com.tenjiku.mtb.exception;
 
-
-
 public class UserNotFoundException extends RuntimeException  {
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/tenjiku/mtb/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tenjiku/mtb/exception/handler/GlobalExceptionHandler.java
@@ -64,6 +64,31 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "User not found", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(UserAlreadyDeletedException.class)
+    public ResponseEntity<ErrorResponse> handleUserAlreadyDeleted(UserAlreadyDeletedException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "User already deleted", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(TheaterNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTheaterNotFound(TheaterNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Theater not found", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(ScreenNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleScreenNotFound(ScreenNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Screen not found", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(NoOfRowsExceedCapacityException.class)
+    public ResponseEntity<ErrorResponse> handleRowExceedsCapacity(NoOfRowsExceedCapacityException ex, WebRequest request) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Number of rows exceeds screen capacity", ex.getMessage(), request);
+    }
+
     // ────── Catch-All Handler ────── //
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/tenjiku/mtb/mapper/ScreenMapper.java
+++ b/src/main/java/com/tenjiku/mtb/mapper/ScreenMapper.java
@@ -1,0 +1,57 @@
+package com.tenjiku.mtb.mapper;
+
+import com.tenjiku.mtb.dto.entry_dto.screen.ScreenDTO;
+import com.tenjiku.mtb.dto.exit_dto.screen.ScreenResponseDTO;
+import com.tenjiku.mtb.dto.exit_dto.screen.SeatResponseDTO;
+import com.tenjiku.mtb.entity.Screen;
+import com.tenjiku.mtb.entity.Seats;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+@Component
+public class ScreenMapper {
+
+    public Screen toEntity(ScreenDTO screenDTO) {
+        if ( screenDTO == null ) {
+            return null;
+        }
+
+        Screen screen= new Screen();
+        screen.setScreenType(screenDTO.getScreenType());
+        screen.setCapacity(screenDTO.getCapacity());
+        screen.setNoOfRows(screenDTO.getNoOfRows());
+        return screen;
+    }
+
+    public ScreenResponseDTO toDTO(Screen screen) {
+        if ( screen == null ) {
+            return null;
+        }
+
+        ScreenResponseDTO screenResponseDTO = new ScreenResponseDTO();
+
+        screenResponseDTO.setScreenId(screen.getScreenId());
+        screenResponseDTO.setScreenType(screen.getScreenType());
+        screenResponseDTO.setTheater(screen.getTheater());
+        screenResponseDTO.setCapacity(screen.getCapacity());
+        screenResponseDTO.setNoOfRows(screen.getNoOfRows());
+        screenResponseDTO.setCreatedAt(screen.getCreatedAt());
+        screenResponseDTO.setCreatedBy(screen.getCreatedBy());
+        screenResponseDTO.setSeats(seatMapper(screen.getSeats()));
+
+        return screenResponseDTO;
+    }
+    public List<SeatResponseDTO> seatMapper(List<Seats> seats){
+        List<SeatResponseDTO> seatRes= new ArrayList<>();
+        for(Seats seat:seats){
+            seatRes.add(SeatResponseDTO.builder()
+                    .seatId(seat.getSeatId())
+                    .name(seat.getName())
+                    .screen(seat.getScreen())
+                    .build());
+        }
+        return seatRes;
+    }
+
+}

--- a/src/main/java/com/tenjiku/mtb/mapper/TheaterEntityMapper.java
+++ b/src/main/java/com/tenjiku/mtb/mapper/TheaterEntityMapper.java
@@ -8,15 +8,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TheaterEntityMapper {
+
     public Theater toEntity(TheaterDTO dto) {
         if ( dto == null ) {
             return null;
         }
-          Theater theater = new Theater();
-       theater.setName(dto.getName());
-       theater.setCity(dto.getCity());
-       theater.setLandmark(dto.getLandmark());
-       theater.setAddress(dto.getAddress());
+
+        Theater theater = new Theater();
+        theater.setName(dto.getName());
+        theater.setCity(dto.getCity());
+        theater.setLandmark(dto.getLandmark());
+        theater.setAddress(dto.getAddress());
         return theater;
     }
 

--- a/src/main/java/com/tenjiku/mtb/repositroy/ScreenRepo.java
+++ b/src/main/java/com/tenjiku/mtb/repositroy/ScreenRepo.java
@@ -1,0 +1,10 @@
+package com.tenjiku.mtb.repositroy;
+
+import com.tenjiku.mtb.entity.Screen;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScreenRepo extends JpaRepository<Screen,String> {
+
+}

--- a/src/main/java/com/tenjiku/mtb/repositroy/SeatRepo.java
+++ b/src/main/java/com/tenjiku/mtb/repositroy/SeatRepo.java
@@ -1,0 +1,9 @@
+package com.tenjiku.mtb.repositroy;
+
+import com.tenjiku.mtb.entity.Seats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeatRepo extends JpaRepository<Seats,String> {
+}

--- a/src/main/java/com/tenjiku/mtb/service/Impl/ScreenServiceImp.java
+++ b/src/main/java/com/tenjiku/mtb/service/Impl/ScreenServiceImp.java
@@ -1,0 +1,71 @@
+package com.tenjiku.mtb.service.Impl;
+
+import com.tenjiku.mtb.dto.entry_dto.screen.ScreenDTO;
+import com.tenjiku.mtb.dto.exit_dto.screen.ScreenResponseDTO;
+import com.tenjiku.mtb.entity.Screen;
+import com.tenjiku.mtb.entity.Seats;
+import com.tenjiku.mtb.entity.Theater;
+import com.tenjiku.mtb.exception.NoOfRowsExceedCapacityException;
+import com.tenjiku.mtb.exception.ScreenNotFoundException;
+import com.tenjiku.mtb.exception.TheaterNotFoundException;
+import com.tenjiku.mtb.mapper.ScreenMapper;
+import com.tenjiku.mtb.repositroy.ScreenRepo;
+import com.tenjiku.mtb.repositroy.SeatRepo;
+import com.tenjiku.mtb.repositroy.TheaterRepo;
+import com.tenjiku.mtb.service.ScreenService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ScreenServiceImp implements ScreenService {
+
+    private final TheaterRepo theaterRepo;
+    private final ScreenRepo screenRepo;
+    private final SeatRepo seatRepo;
+    private final ScreenMapper screenMapper;
+
+    @Override
+    public ScreenResponseDTO createScreen(String theaterId, ScreenDTO screenDTO) {
+        return screenMapper.toDTO(screenRepo.save(merge(screenMapper.toEntity(screenDTO),theaterRepo.findById(theaterId).orElseThrow(()-> new TheaterNotFoundException(" Theater not found with this Id :"+theaterId)))));
+    }
+
+    @Override
+    public ScreenResponseDTO findScreenById(String theaterId, String screenId) {
+        if (theaterRepo.existsById(theaterId)) {
+            if (screenRepo.existsById(screenId))
+                return screenMapper.toDTO(screenRepo.findById(screenId).orElseThrow(()-> new ScreenNotFoundException(" no Screen exist with this id : "+screenId)));
+        }
+        throw new TheaterNotFoundException("Theater not found by Id");
+
+    }
+
+    private Screen merge(Screen screen,Theater theater){
+        screen.setTheater(theater);
+        if (screen.getNoOfRows() > screen.getCapacity())
+            throw new NoOfRowsExceedCapacityException("The no.of rows exceed the capacity");
+        screen.setSeats(generateSeats(screen));
+        screen.setCreatedBy(theater.getCreatedBy());
+        return  screen;
+    }
+    private List<Seats> generateSeats(Screen screen ){
+        List<Seats> seats = new ArrayList<>();
+        int noOfSeatsPerRow = screen.getCapacity() / screen.getNoOfRows();
+        char row = 'A';
+        for (int i = 1, j = 1; i <= screen.getCapacity(); i++, j++) {
+            Seats seat = new Seats();
+            seat.setScreen(screen);
+            seat.setDelete(false);
+            seat.setName(row + "" + j);
+            seatRepo.save(seat);
+            seats.add(seat);
+            if (j == noOfSeatsPerRow) {
+                j = 0;
+                row++;
+            }
+        }
+        return seats;
+    }
+}

--- a/src/main/java/com/tenjiku/mtb/service/Impl/TheaterServiceImp.java
+++ b/src/main/java/com/tenjiku/mtb/service/Impl/TheaterServiceImp.java
@@ -25,17 +25,16 @@ public class TheaterServiceImp implements TheaterService {
 
     @Override
     public TheaterResponceDTO register(String ownerId, TheaterDTO theaterDTO) {
-        System.out.println("inbound Service :"+theaterDTO);
         // Step 1: Fetch the TheaterOwner or throw if not found
         TheaterOwner theaterOwner = (TheaterOwner) userRepo.findById(ownerId)
                 .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + ownerId));
-        System.out.println("theaterOwner without theater "+theaterOwner);
+
         // Step 2: Convert DTO to Entity and set ownership metadata
         Theater theater = theaterMapper.toEntity(theaterDTO);
-        System.out.println("Convert DTO to Entity"+theater);
+
         theater.setCreatedBy(theaterOwner.getEmail());
         theater.setTheaterOwner(theaterOwner);
-        System.out.println("theater Entity owner"+theater);
+
         // Step 3: Save theater entity
         Theater savedTheater = theaterRepo.save(theater);
 
@@ -45,7 +44,7 @@ public class TheaterServiceImp implements TheaterService {
         }
         theaterOwner.getTheaters().add(savedTheater);
         userRepo.save(theaterOwner);
-        System.out.println("theaterOwner with theater "+theaterOwner);
+
         // Step 5: Return the response DTO
         return theaterMapper.toDTO(savedTheater);
     }

--- a/src/main/java/com/tenjiku/mtb/service/ScreenService.java
+++ b/src/main/java/com/tenjiku/mtb/service/ScreenService.java
@@ -1,0 +1,12 @@
+package com.tenjiku.mtb.service;
+
+import com.tenjiku.mtb.dto.entry_dto.screen.ScreenDTO;
+import com.tenjiku.mtb.dto.exit_dto.screen.ScreenResponseDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ScreenService {
+    ScreenResponseDTO createScreen(String theaterId, ScreenDTO screenDTO);
+
+    ScreenResponseDTO findScreenById(String theaterId, String screenId);
+}


### PR DESCRIPTION
Description:
Create a POST API endpoint to add a new screen to an existing theater. The endpoint must automatically generate seats based on the screen's capacity and the number of rows specified, following a structured seat naming convention.
Task:
Develop a POST endpoint at URI /theaters/{theaterId}/screens.
Accept ScreenRequest as the request body and theaterId as a PathVariable.
Validate if the theater with the given theaterId exists.
If the theater exists:
Create a new Screen entity populated with the request data.
Auto-generate seats:
Calculate seatsPerRow = capacity / noOfRows.
Seat naming should follow row letters (A, B, C...) and numbers (A1, A2, ..., B1, B2, ...).
Associate generated seats with the created screen.
Set up cascading from Screen to Seats to ensure seats are auto-persisted when the screen is saved.
Persist the new screen entity.
Return a TheaterResponse including a list of SeatResponse objects.
Acceptance Criteria:
A valid screen is created and associated with the specified theater.
Seats are generated automatically based on the provided capacity and noOfRows.
Each seat has a proper seat name following the format (e.g., A1, A2, ..., B1, B2, ...).
Screen and seats are saved in a single transaction.
API response must be a TheaterResponse object embedding a list of SeatResponse objects.
Each SeatResponse must contain seatId and seatName.
Additional Notes:
Ensure edge cases like non-even capacity/noOfRows division are handled gracefully.
Add proper validation and error handling if the theater is not found.
Ensure efficient database operations and avoid N+1 issues when fetching seats.
Description:
Create a GET API endpoint to retrieve screen details by its unique identifier. The response should include the screen information along with the list of seats associated with the screen.
Task:
Develop a GET API endpoint at URI /screens/{screenId}.
Accept screenId as a PathVariable.
Find the Screen entity by its screenId.
Ensure seats are eagerly loaded with the screen entity to avoid additional database queries.
Map the screen and its seats to a ScreenResponse DTO.
Return the ScreenResponse including a list of SeatResponse objects.
Acceptance Criteria:
The API successfully retrieves the screen details using screenId.
The response contains:
Screen basic details (e.g., screen name, capacity).
List of associated seats, each represented as a SeatResponse (containing at least seatId and seatName).
Seats must be loaded eagerly and should not cause N+1 query issues.
If the screenId does not exist, return an appropriate error response (e.g., 404 Not Found).
Additional Notes:
Use appropriate mapping (manual or mapper libraries) to convert the entity to DTO.
Ensure minimal and efficient database access.
Apply best practices for error handling and validation.